### PR TITLE
用代理模式重写VectorImpl

### DIFF
--- a/src/main/kotlin/org/mechdancer/algebra/equation/LinearEquation.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/LinearEquation.kt
@@ -5,32 +5,27 @@ import org.mechdancer.algebra.vector.Vector
 
 /**
  * LinearEquation
+ * 线性方程组，即其中所有未知数指数为1的方程组
  */
 interface LinearEquation {
 
 	/**
 	 * Coefficient of this equation
 	 * represents by a matrix
+	 * 系数矩阵
 	 */
 	val coefficient: Matrix
 
 	/**
 	 * Constant of this equation
 	 * represents by a vector
+	 * 常数项
 	 */
 	val constant: Vector
 
 	/**
 	 * Whether it's homogeneous
+	 * 齐次性，常数项为零向量称作齐次
 	 */
 	val isHomogeneous: Boolean
-
-	/**
-	 * Solve this equation
-	 * See [Solver.solve]
-	 *
-	 * @param solver solver
-	 * @return result
-	 */
-	fun solve(solver: Solver): Vector
 }

--- a/src/main/kotlin/org/mechdancer/algebra/equation/Solution.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/Solution.kt
@@ -1,0 +1,16 @@
+package org.mechdancer.algebra.equation
+
+import org.mechdancer.algebra.matrix.Matrix
+
+/**
+ * n元一次方程组当且仅当其中线性无关的方程数目等于其解的维数时才有唯一解
+ * 设独立方程数目为m，有：
+ * -> m < n ∞ 欠定方程组
+ * -> m = n 1 适定方程组
+ * -> m > n 0 超定方程组
+ * 欠定方程与适定方程的解即[Solution]
+ * 表达为 a_1 * x_1 + a_2 * x_2 + ... + a_n-m * x_n-m + b = 0
+ * 其中{a_1, a_2, ... , a_n-m, b}组成n行n-m+1列的矩阵
+ * TODO 求解超定方程需要使用以最小二乘法为代表的某种拟合方法
+ */
+typealias Solution = Matrix

--- a/src/main/kotlin/org/mechdancer/algebra/equation/Solver.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/Solver.kt
@@ -2,16 +2,15 @@ package org.mechdancer.algebra.equation
 
 import org.mechdancer.algebra.vector.Vector
 
-@FunctionalInterface
 /**
  * Solver of linearEquation
  * see [LinearEquation]
  */
+@FunctionalInterface
 interface Solver {
 	/**
 	 * Solve the equation
-	 *
-	 * @param equation equation
+	 * @param  equation equation
 	 * @return result as a vector
 	 */
 	fun solve(equation: LinearEquation): Vector

--- a/src/main/kotlin/org/mechdancer/algebra/equation/SuperSolver.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/SuperSolver.kt
@@ -1,0 +1,5 @@
+package org.mechdancer.algebra.equation
+
+interface SuperSolver {
+	fun solve(equation: LinearEquation): Solution
+}

--- a/src/main/kotlin/org/mechdancer/algebra/equation/impl/LinearEquationImpl.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/impl/LinearEquationImpl.kt
@@ -1,14 +1,13 @@
 package org.mechdancer.algebra.equation.impl
 
 import org.mechdancer.algebra.equation.LinearEquation
-import org.mechdancer.algebra.equation.Solver
 import org.mechdancer.algebra.matrix.Matrix
 import org.mechdancer.algebra.vector.Vector
+import org.mechdancer.algebra.vector.isZero
 
 data class LinearEquationImpl(
-		override val coefficient: Matrix,
-		override val constant: Vector)
+	override val coefficient: Matrix,
+	override val constant: Vector)
 	: LinearEquation {
-	override val isHomogeneous: Boolean = constant.data.all { it == .0 }
-	override fun solve(solver: Solver): Vector = solver.solve(this)
+	override val isHomogeneous: Boolean = constant.isZero()
 }

--- a/src/main/kotlin/org/mechdancer/algebra/equation/solvers/CommonSolver.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/solvers/CommonSolver.kt
@@ -18,7 +18,7 @@ object CommonSolver : Solver {
 					" which has innumerable untrivial solutions")
 
 		val augmented = operateMatrixDataMutable(equation.coefficient.data) {
-			addColumn(equation.constant.data)
+			addColumn(equation.constant.toList())
 		}.toMatrix()
 		val s = augmented.rowEchelon()
 		return ImmutableMatrixDataUtil.splitColumn(s.data, s.column - 1).toVector()

--- a/src/main/kotlin/org/mechdancer/algebra/equation/solvers/CramerSolver.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/equation/solvers/CramerSolver.kt
@@ -26,7 +26,7 @@ object CramerSolver : Solver {
 		if (d.calculate() == .0) throw IllegalArgumentException("matrix is singular")
 
 		return (0 until equation.coefficient.column).fold(mutableListOf<Double>()) { acc, i ->
-			acc.add(d.replaceColumn(i, equation.constant.data).calculate() / d.calculate())
+			acc.add(d.replaceColumn(i, equation.constant.toList()).calculate() / d.calculate())
 			acc
 		}.toVector()
 

--- a/src/main/kotlin/org/mechdancer/algebra/matrix/Matrix.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/matrix/Matrix.kt
@@ -7,17 +7,20 @@ import org.mechdancer.algebra.vector.Vector
 
 /**
  * Matrix
+ * 矩阵
  */
 interface Matrix {
 
 	/**
 	 * The dimension of this matrix
 	 * (Only square matrix has)
+	 *
+	 * 方阵的维数
+	 * 试图获取非方阵的维数会产生异常
 	 */
 	val dimension: Int
 
 	/**
-	 * Matrix data
 	 * See [MatrixData]
 	 */
 	val data: MatrixData

--- a/src/main/kotlin/org/mechdancer/algebra/matrix/MatrixExtensions.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/matrix/MatrixExtensions.kt
@@ -24,7 +24,7 @@ typealias MatrixElement = List<Double>
  * @return result
  */
 fun Vector.toMatrix(): Matrix =
-		List(dimension) { r -> List(1) { data[r] } }.toMatrix()
+	List(dimension) { r -> List(1) { toList()[r] } }.toMatrix()
 
 /**
  * Use MatrixData to build a matrix

--- a/src/main/kotlin/org/mechdancer/algebra/vector/Vector.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/vector/Vector.kt
@@ -1,45 +1,75 @@
 package org.mechdancer.algebra.vector
 
 import org.mechdancer.algebra.dimensionArgumentError
-import org.mechdancer.algebra.matrix.MatrixElement
 import org.mechdancer.algebra.vector.impl.Vector2D
 import org.mechdancer.algebra.vector.impl.Vector3D
 import org.mechdancer.algebra.vector.impl.VectorImpl
 
 /**
+ * Vector
  * 向量
  */
 interface Vector {
-	/** 维数 */
+	/**
+	 * Dimension
+	 * 维数
+	 */
 	val dimension: Int
 
-	/** 数据 */
-	val data: MatrixElement
-
-	/** @return 第[index]维上的数据 */
+	/**
+	 * Get item on the [index] dimension
+	 * 获取指定维度上的值
+	 */
 	operator fun get(index: Int): Double
 
-	/** 相加 */
+	/**
+	 * Plus another vector, then return a new vector
+	 * 加上一个向量并返回新的向量
+	 */
 	operator fun plus(other: Vector): Vector
 
-	/** 相减 */
+	/**
+	 * Plus a vector of opposite direction
+	 * 加上一个与[other]反向的向量
+	 */
 	operator fun minus(other: Vector): Vector
 
-	/** 数乘 */
+	/**
+	 * Multiply a number to return a new vector of different length
+	 * 数乘，乘以系数改变向量的长度
+	 */
 	operator fun times(k: Double): Vector
 
-	/** 内积 */
+	/**
+	 * Dot product
+	 * 点乘/内积/数量积
+	 */
 	infix fun dot(other: Vector): Double
 
-	/** @return 模长 */
-	fun norm(): Double
+	/**
+	 * Norm
+	 * 模长
+	 */
+	val norm: Double
 
-	/** 转简单字符串 */
+	/**
+	 * Transform to a [String] which occupies only one line
+	 * 转为只占一行的字符串形式
+	 */
 	fun toSimpleString(): String
 
+	/**
+	 * Transform to a [Double] [List]
+	 * 转为双精度浮点数列表
+	 */
+	fun toList(): List<Double>
+
 	companion object {
-		/** 假构造器 */
-		operator fun invoke(data: MatrixElement): Vector =
+		/**
+		 * Build a vector from its data
+		 * 从数字的列表构造向量
+		 */
+		operator fun invoke(data: List<Double>): Vector =
 			if (data.isEmpty()) throw dimensionArgumentError
 			else when (data.size) {
 				2    -> Vector2D(data[0], data[1])
@@ -54,7 +84,7 @@ interface Vector {
 				when (dimension) {
 					2    -> Vector2D(.0, .0)
 					3    -> Vector3D(.0, .0, .0)
-					else -> DoubleArray(dimension).toList().toVector()
+					else -> VectorImpl(List(dimension) { .0 })
 				}
 	}
 }

--- a/src/main/kotlin/org/mechdancer/algebra/vector/VectorExtensions.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/vector/VectorExtensions.kt
@@ -39,18 +39,18 @@ operator fun Vector.div(k: Double) = this * (1 / k)
 operator fun Vector.unaryMinus() = this * -1.0
 
 /** @return 单位向量 */
-fun Vector.normalize() = this / norm()
+fun Vector.normalize() = this / norm
 
 /** 计算两个向量之间的某种关系 */
 enum class Relation(val between: (Vector, Vector) -> Double) {
 	/** 用弧度表示的夹角 */
-	IncludedAngle({ one, other -> acos(one dot other / one.norm() / other.norm()) }),
+	IncludedAngle({ one, other -> acos(one dot other / one.norm / other.norm) }),
 
 	/** 欧式距离 */
-	Euclid({ one, other -> (one - other).norm() }),
+	Euclid({ one, other -> (one - other).norm }),
 
 	/** 曼哈顿距离 */
-	Manhattan({ one, other -> (one - other).data.sum() }),
+	Manhattan({ one, other -> (one - other).toList().sum() }),
 }
 
 /** @return 与[other]间用弧度表示的夹角 */
@@ -70,17 +70,33 @@ fun Vector.copy(vararg change: Pair<Int, Double>): Vector {
 
 /** 从向量选取指定的维度组成新的向量 */
 fun Vector.select(vararg index: Int): Vector =
-	data.filterIndexed { i, _ -> i in index }.toVector()
+	toList().filterIndexed { i, _ -> i in index }.toVector()
 
 /** 从向量选取指定的维度组成新的向量 */
 fun Vector.select(range: IntRange): Vector =
-	data.drop(range.first).take(range.last - range.first + 1).toVector()
+	toList().drop(range.first).take(range.last - range.first + 1).toVector()
+
+/** 判断是否零向量 */
+fun Vector.isZero() = norm == 0.0
+
+/** 判断是否非零向量 */
+fun Vector.isNotZero() = norm != 0.0
+
+/** 判断是否单位向量 */
+fun Vector.isNormalized() = norm == 1.0
+
+/** 判断是否非单位向量 */
+fun Vector.isNotNormalized() = norm != 1.0
+
+//解绑定
 
 operator fun Vector.component1() = this[0]
 operator fun Vector.component2() = this[1]
 operator fun Vector.component3() = this[2]
 operator fun Vector.component4() = this[3]
 operator fun Vector.component5() = this[4]
+
+// 其中各维度的名字
 
 val Vector.x get() = this[0]
 val Vector.y get() = this[1]

--- a/src/main/kotlin/org/mechdancer/algebra/vector/impl/Vector2D.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/vector/impl/Vector2D.kt
@@ -15,7 +15,7 @@ class Vector2D(x: Double, y: Double) : VectorImpl(listOf(x, y)) {
 		operator fun invoke(vector: Vector) =
 			vector as? Vector2D
 				?: (vector as VectorImpl).run {
-					Vector2D(getOrElse(0) { .0 }, getOrElse(1) { .0 })
+					Vector2D(getOrElse(0, .0), getOrElse(1, .0))
 				}
 	}
 }

--- a/src/main/kotlin/org/mechdancer/algebra/vector/impl/Vector3D.kt
+++ b/src/main/kotlin/org/mechdancer/algebra/vector/impl/Vector3D.kt
@@ -23,9 +23,9 @@ class Vector3D(x: Double, y: Double, z: Double) : VectorImpl(listOf(x, y, z)) {
 			vector as? Vector3D
 				?: (vector as VectorImpl).run {
 					Vector3D(
-						vector.getOrElse(0) { .0 },
-						vector.getOrElse(1) { .0 },
-						vector.getOrElse(2) { .0 })
+						vector.getOrElse(0, .0),
+						vector.getOrElse(1, .0),
+						vector.getOrElse(2, .0))
 				}
 	}
 }

--- a/src/test/kotlin/org/mechdancer/algebra/test/TestEquation.kt
+++ b/src/test/kotlin/org/mechdancer/algebra/test/TestEquation.kt
@@ -12,9 +12,9 @@ import org.mechdancer.algebra.vector.vectorOf
 class TestEquation {
 
 	/*
-	2x+3y-5z=3
-	x-2y+z=0
-	3x+y+3z=7
+	 * 2x+3y-5z=3
+	 * x-2y+z=0
+	 * 3x+y+3z=7
 	 */
 
 	private val equation = linearEquation {
@@ -32,7 +32,7 @@ class TestEquation {
 	fun testCommonSolve() {
 		try {
 			Assert.assertEquals(vectorOf(10.0 / 7.0, 1.0, 4.0 / 7.0),
-					equation.solve(CommonSolver))
+				CommonSolver.solve(equation))
 		} catch (e: AssertionError) {
 			println("qwq")
 		}
@@ -41,7 +41,6 @@ class TestEquation {
 	@Test
 	fun testCramerSolve() {
 		Assert.assertEquals(vectorOf(10.0 / 7.0, 1.0, 4.0 / 7.0),
-				equation.solve(CramerSolver))
+			CramerSolver.solve(equation))
 	}
-
 }

--- a/src/test/kotlin/org/mechdancer/algebra/test/TestVector.kt
+++ b/src/test/kotlin/org/mechdancer/algebra/test/TestVector.kt
@@ -16,7 +16,7 @@ class TestVector {
 
 		Assert.assertEquals(2, vector2D.dimension)
 		Assert.assertEquals(1.0, vector2D.x, .0)
-		Assert.assertEquals(sqrt(2.0), vector2D.norm(), .0)
+		Assert.assertEquals(sqrt(2.0), vector2D.norm, .0)
 		Assert.assertEquals(Vector2D(3.0, 3.0), vector2D + Vector2D(2.0, 2.0))
 		Assert.assertEquals(Vector2D(2.0, 2.0), vector2D * 2.0)
 		Assert.assertEquals(Vector2D(-1.0, -1.0), -vector2D)


### PR DESCRIPTION
Signed-off-by: YangDR <ydrml@hotmail.com>

线性方程组加了一点准备加解欠定方程组的东西

主要是改了Vector接口：
1. 把可以不是操作的norm改成了属性；
2. 把data改成了toList()，因为底层可以不用List实现，此时就没有直接的data
3. 相应改了VectorImpl的实现